### PR TITLE
Add markdown color plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "license": "ISC",
       "devDependencies": {
         "@maginapp/vuepress-plugin-katex": "^1.0.11",
+        "markdown-it-color": "^2.1.1",
         "prettier": "^1.19.1",
         "vuepress": "^1.8.2",
         "vuepress-plugin-seo": "^0.1.4",
@@ -7333,6 +7334,12 @@
         "deepmerge": "^1.5.2",
         "javascript-stringify": "^1.6.0"
       }
+    },
+    "node_modules/markdown-it-color": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-color/-/markdown-it-color-2.1.1.tgz",
+      "integrity": "sha512-GqXOSjT+RdGvxjdmPfRS/9XDr5dg4e2kC/mXbXK5Y1lbh/rVepoeaUGaD0Lmi1qS5M6cnbm9GrC8bu9YY8rRKQ==",
+      "dev": true
     },
     "node_modules/markdown-it-container": {
       "version": "2.0.0",
@@ -19518,6 +19525,12 @@
           }
         }
       }
+    },
+    "markdown-it-color": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-color/-/markdown-it-color-2.1.1.tgz",
+      "integrity": "sha512-GqXOSjT+RdGvxjdmPfRS/9XDr5dg4e2kC/mXbXK5Y1lbh/rVepoeaUGaD0Lmi1qS5M6cnbm9GrC8bu9YY8rRKQ==",
+      "dev": true
     },
     "markdown-it-container": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "homepage": "https://github.com/SparklingRita/resumos-meec#readme",
   "devDependencies": {
     "@maginapp/vuepress-plugin-katex": "^1.0.11",
+    "markdown-it-color": "^2.1.1",
     "prettier": "^1.19.1",
     "vuepress": "^1.8.2",
     "vuepress-plugin-seo": "^0.1.4",

--- a/src/.vuepress/config.js
+++ b/src/.vuepress/config.js
@@ -176,6 +176,9 @@ module.exports = {
     ],
    
   ],
- 
-  
+  markdown: {
+    extendMarkdown: (md) => {
+      md.use(require('markdown-it-color').default);
+    },
+  },
 };

--- a/src/.vuepress/styles/colors.styl
+++ b/src/.vuepress/styles/colors.styl
@@ -1,0 +1,57 @@
+$red = #E03E3E
+$redDark = #ff7369
+$green = #0F7B6C
+$greenDark = #4DAB9A
+$blue = #0B6E99
+$blueDark = #529CCA
+$pink = #AD1A72
+$pinkDark = #E255A1
+$purple = #6940A5
+$purpleDark = #946DD7
+$yellow = #DFAB01
+$yellowDark = #FFDC49
+$orange = #D9730D
+$orangeDark = #FFA334
+$brown = #64473A
+$brownDark = #937264
+
+@require './palette.styl'
+
+:root
+  --colorRed $red
+  --colorGreen $green
+  --colorBlue $blue
+  --colorPink $pink
+  --colorPurple $purple
+  --colorYellow $yellow
+  --colorOrange $orange
+  --colorBrown $brown
+
+  @media (prefers-color-scheme dark)
+    --colorRed $redDark
+    --colorGreen $greenDark
+    --colorBlue $blueDark
+    --colorPink $pinkDark
+    --colorPurple $purpleDark
+    --colorYellow $yellowDark
+    --colorOrange $orangeDark
+    --colorBrown $brownDark
+
+.md-colorify
+  &.md-colorify--red
+    color: var(--colorRed)
+  &.md-colorify--green
+    color: var(--colorGreen)
+  &.md-colorify--blue
+    color: var(--colorBlue)
+  &.md-colorify--pink
+    color: var(--colorPink)
+  &.md-colorify--purple
+    color: var(--colorPurple)
+  &.md-colorify--yellow
+    color: var(--colorYellow)
+  &.md-colorify--orange
+    color: var(--colorOrange)
+  &.md-colorify--brown
+    color: var(--colorBrown)
+    

--- a/src/.vuepress/styles/index.styl
+++ b/src/.vuepress/styles/index.styl
@@ -4,6 +4,7 @@
  * ref：https://v1.vuepress.vuejs.org/config/#index-styl
  */
 
+@import 'colors'
 
 @media(prefers-color-scheme: dark)
   .invert-dark


### PR DESCRIPTION
This PR adds a the `markdown-it-color` extension to VuePress.

This allows colors to be used with the following syntax:

```md
This is normal text.
{red}(This is red text)
```